### PR TITLE
Update GH Actions due to deprecation of Node 20

### DIFF
--- a/.github/actions/build-project/action.yml
+++ b/.github/actions/build-project/action.yml
@@ -8,7 +8,7 @@ inputs:
   node-version:
     description: 'Node.js version to use (must be valid semver)'
     required: false
-    default: '22.19.0'
+    default: '24.16.0'
   build-command:
     description: 'Build command to run (should use pnpm)'
     required: false
@@ -29,7 +29,7 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Cache Next.js build
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ${{ github.workspace }}/.next/cache

--- a/.github/actions/bump-version/action.yml
+++ b/.github/actions/bump-version/action.yml
@@ -20,7 +20,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         token: ${{ inputs.github-token }}

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -8,7 +8,7 @@ inputs:
   node-version:
     description: 'Node.js version to use'
     required: false
-    default: '22.19.0'
+    default: '24.16.0'
   pnpm-version:
     description: 'pnpm version to use'
     required: false
@@ -18,12 +18,12 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: ${{ inputs.pnpm-version }}
 
@@ -34,7 +34,7 @@ runs:
         echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Cache pnpm store
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -42,7 +42,7 @@ runs:
           ${{ runner.os }}-pnpm-store-
 
     - name: Cache node_modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           node_modules

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build project
         uses: nightstem/site/.github/actions/build-project@main
@@ -60,7 +60,7 @@ jobs:
           project-name: ${{ secrets.CLOUDFLARE_PROJECT_NAME }}
 
       - name: Comment preview URL on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: github.event_name == 'pull_request'
         with:
           script: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Generate App Token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Create pre-release
         id: create-pre-release-step
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -100,7 +100,7 @@ jobs:
       deployment-url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - name: Checkout updated code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 
@@ -136,20 +136,20 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Generate App Token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: site
 
       - name: Update pre-release with deployment URL
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ steps.generate-token.outputs.token }}
           script: |
@@ -283,11 +283,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate App Token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -316,14 +316,14 @@ jobs:
     steps:
       - name: Generate App Token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: site
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build project
         uses: nightstem/site/.github/actions/build-project@main

--- a/.github/workflows/on-pull-request-close.yml
+++ b/.github/workflows/on-pull-request-close.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Clear Cache
         uses: jhonny17/actions/clear-cache@main

--- a/.github/workflows/run-code-checks.yml
+++ b/.github/workflows/run-code-checks.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         uses: nightstem/site/.github/actions/install-dependencies@main
@@ -50,7 +50,7 @@ jobs:
             description: 'Test coverage'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check prettier
         if: matrix.check == 'prettier'

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "packageManager": "pnpm@10.17.0",
   "engines": {
-    "node": ">=22.19.0",
+    "node": ">=24.16.0",
     "pnpm": ">=10.17.0",
     "npm": "Please use pnpm",
     "yarn": "Please use pnpm"


### PR DESCRIPTION
## Summary

GitHub is retiring the Node.js 20 runtime for GitHub Actions. This PR bumps all affected actions to their current major (Node 24 runtime) and aligns the project's own Node version to match.

### Actions updated

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-node` | `@v4` | `@v6` |
| `pnpm/action-setup` | `@v4` | `@v6` |
| `actions/cache` | `@v4` | `@v5` |
| `actions/github-script` | `@v7` | `@v9` |
| `actions/create-github-app-token` | `@v1` | `@v3` |

### Node version

Pinned Node from `22.19.0` → `24.16.0` in:
- `package.json` (`engines.node`)
- `.github/actions/install-dependencies/action.yml` (default input)
- `.github/actions/build-project/action.yml` (default input)

### Out of scope

`cloudflare/wrangler-action` stays at `@v3` — it was not flagged as Node 20 and `@v4` changes the default Wrangler version, which is a separate concern.

## Test plan

- [x] Deploy preview workflow runs green with no "Node.js 20 actions are deprecated" annotation in the logs
- [x] All code quality checks pass (prettier, linter, tests, coverage)